### PR TITLE
Various Bot Improvements

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/HubModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/HubModule.cs
@@ -53,7 +53,7 @@ namespace SysBot.Pokemon.Discord
             }
 
             var countC = hub.Queues.Clone.Count;
-            if (countC == 0)
+            if (countC != 0)
             {
                 var nextC = hub.Queues.Clone.TryPeek(out var detailC, out _);
                 var nextMsgC = nextC ? $"{detailC.Trainer.TrainerName}" : "None!";
@@ -68,7 +68,7 @@ namespace SysBot.Pokemon.Discord
             }
 
             var countD = hub.Queues.Dudu.Count;
-            if (countD == 0)
+            if (countD != 0)
             {
                 var nextD = hub.Queues.Dudu.TryPeek(out var detailD, out _);
                 var nextMsgD = nextD ? $"{detailD.Trainer.TrainerName}" : "None!";

--- a/SysBot.Pokemon/BotTrade/PokeTradeLogNotifier.cs
+++ b/SysBot.Pokemon/BotTrade/PokeTradeLogNotifier.cs
@@ -25,8 +25,7 @@ namespace SysBot.Pokemon
 
         public void TradeFinished(PokeRoutineExecutor routine, PokeTradeDetail<T> info, T result)
         {
-            LogUtil.LogInfo($"Finished trade for {info.Trainer.TrainerName}, sending {(Species)info.TradeData.Species}", routine.Connection.Name);
-            LogUtil.LogInfo($"Received: {(Species)result.Species}.", routine.Connection.Name);
+            LogUtil.LogInfo($"Finished trading {info.Trainer.TrainerName} {(Species)info.TradeData.Species} for {(Species)result.Species}", routine.Connection.Name);
             OnFinish?.Invoke(routine);
         }
 

--- a/SysBot.Pokemon/Queues/TradeQueueManager.cs
+++ b/SysBot.Pokemon/Queues/TradeQueueManager.cs
@@ -49,7 +49,7 @@ namespace SysBot.Pokemon
                 await Task.Delay(1_000, token).ConfigureAwait(false);
                 if (Queue.Count != 0)
                     continue;
-                if (Hub.Bots.All(z => z.Config.CurrentRoutineType != PokeRoutineType.LinkTrade))
+                if (Hub.Bots.All(z => (z.Config.CurrentRoutineType != PokeRoutineType.LinkTrade && z.Config.CurrentRoutineType != PokeRoutineType.FlexTrade)))
                     continue;
                 if (!Hub.Config.DistributeWhileIdle)
                     continue;

--- a/SysBot.Pokemon/Structures/Ledy/LedyDistributor.cs
+++ b/SysBot.Pokemon/Structures/Ledy/LedyDistributor.cs
@@ -22,7 +22,8 @@ namespace SysBot.Pokemon
             if (speciesMatch != NoMatchSpecies && pk.Species != (int)speciesMatch)
                 return GetRandomResponse();
 
-            var nick = pk.Nickname;
+            // All the files should be loaded in as lowercase, regular-width text with no white spaces.
+            var nick = StringsUtil.Sanitize(pk.Nickname);
             if (UserRequests.TryGetValue(nick, out var match))
                 return new LedyResponse<T>(match.RequestInfo, LedyResponseType.MatchRequest);
             if (Distribution.TryGetValue(nick, out match))

--- a/SysBot.Pokemon/Structures/Ledy/PokemonPool.cs
+++ b/SysBot.Pokemon/Structures/Ledy/PokemonPool.cs
@@ -87,7 +87,13 @@ namespace SysBot.Pokemon
 
                 Add(dest);
                 var fn = Path.GetFileNameWithoutExtension(file);
-                Files.Add(fn, new LedyRequest<T>(dest, fn));
+                fn = StringsUtil.Sanitize(fn);
+
+                // Since file names can be sanitized to the same string, only add one of them.
+                if (!Files.ContainsKey(fn))
+                    Files.Add(fn, new LedyRequest<T>(dest, fn));
+                else
+                    LogUtil.LogInfo("Provided pk8 was not added due to duplicate name: " + dest.FileName, nameof(PokemonPool<T>));
                 loadedAny = true;
             }
 

--- a/SysBot.Pokemon/Util/StringsUtil.cs
+++ b/SysBot.Pokemon/Util/StringsUtil.cs
@@ -1,0 +1,16 @@
+﻿using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SysBot.Pokemon
+{
+    public static class StringsUtil
+    {
+        public static string Sanitize(string input)
+        {
+            /* Remove all non-alphanumeric characters, convert wide chars to narrow, and lowercase. */
+            var normalized = Regex.Replace(input, "[^a-zA-Z0-9ａ-ｚＡ-Ｚ０-９]", "");
+            normalized = normalized.Normalize(NormalizationForm.FormKC).ToLower();
+            return normalized;
+        }
+    }
+}


### PR DESCRIPTION
- Fixed an issue with $status only showing queues when empty
- Made FlexTrade display the type of trade
- Tweaked delays for dudu/link/clone trades
- Enabled KOR support for dudu/link/clone trades
- Improved cloning trades -- bot only tries to trade once user offers a new mon to trade
- Fixed messages summarizing results of a trade
- Fixed FlexTrade not defaulting to random trades when idle
- Improved Ledy handling of nicknames and filenames -- all names are sanitized to be lowercase-only, alphanumeric-only, and wide char ->narrow char
- Minor text edits