### PR TITLE
Reduce user error, German compatibility, other minor updates

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/CloneModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/CloneModule.cs
@@ -24,7 +24,7 @@ namespace SysBot.Pokemon.Discord
 
         [Command("clone")]
         [Alias("c")]
-        [Summary("Clones the Pokemon you show via Link Trade.")]
+        [Summary("Clones the Pokémon you show via Link Trade.")]
         [RequireQueueRole(nameof(DiscordManager.RolesClone))]
         public async Task CloneAsync()
         {

--- a/SysBot.Pokemon.Discord/Commands/DuduModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/DuduModule.cs
@@ -14,7 +14,7 @@ namespace SysBot.Pokemon.Discord
 
         [Command("seedCheck")]
         [Alias("dudu", "d", "sc")]
-        [Summary("Checks the seed for a pokemon.")]
+        [Summary("Checks the seed for a Pokémon.")]
         [RequireQueueRole(nameof(DiscordManager.RolesDudu))]
         public async Task SeedCheckAsync(int code)
         {
@@ -24,7 +24,7 @@ namespace SysBot.Pokemon.Discord
 
         [Command("seedCheck")]
         [Alias("dudu", "d", "sc")]
-        [Summary("Checks the seed for a pokemon.")]
+        [Summary("Checks the seed for a Pokémon.")]
         [RequireQueueRole(nameof(DiscordManager.RolesDudu))]
         public async Task SeedCheckAsync()
         {

--- a/SysBot.Pokemon.Discord/Helpers/DiscordTradeNotifier.cs
+++ b/SysBot.Pokemon.Discord/Helpers/DiscordTradeNotifier.cs
@@ -25,14 +25,14 @@ namespace SysBot.Pokemon.Discord
         public void TradeInitialize(PokeRoutineExecutor routine, PokeTradeDetail<T> info)
         {
             var receive = Data.Species == 0 ? string.Empty : $" ({Data.Nickname})";
-            Context.User.SendMessageAsync($"Initializing trade{receive}. Please be ready. Your code is {Code:0000}.").ConfigureAwait(false);
+            Context.User.SendMessageAsync($"Initializing trade{receive}. Please be ready. Your code is **{Code:0000}**.").ConfigureAwait(false);
         }
 
         public void TradeSearching(PokeRoutineExecutor routine, PokeTradeDetail<T> info)
         {
             var name = Info.TrainerName;
             var trainer = string.IsNullOrEmpty(name) ? string.Empty : $", {name}";
-            Context.User.SendMessageAsync($"I'm searching for you{trainer}! Your code is {Code:0000}.").ConfigureAwait(false);
+            Context.User.SendMessageAsync($"I'm waiting for you{trainer}! Your code is **{Code:0000}**. My IGN is **{routine.InGameName}**.").ConfigureAwait(false);
         }
 
         public void TradeCanceled(PokeRoutineExecutor routine, PokeTradeDetail<T> info, PokeTradeResult msg)
@@ -44,7 +44,7 @@ namespace SysBot.Pokemon.Discord
         public void TradeFinished(PokeRoutineExecutor routine, PokeTradeDetail<T> info, T result)
         {
             OnFinish?.Invoke(routine);
-            var message = Data.Species != 0 ? $"Trade finished. Enjoy your {(Species)Data.Species}!" : "Trade finished. Enjoy your Pokemon!";
+            var message = Data.Species != 0 ? $"Trade finished. Enjoy your {(Species)Data.Species}!" : "Trade finished. Enjoy your Pokémon!";
             Context.User.SendMessageAsync(message).ConfigureAwait(false);
             Context.User.SendPKMAsync(result, "Here's what you traded me!").ConfigureAwait(false);
         }

--- a/SysBot.Pokemon.Twitch/Helpers/TwitchCommandsHelper.cs
+++ b/SysBot.Pokemon.Twitch/Helpers/TwitchCommandsHelper.cs
@@ -19,7 +19,7 @@ namespace SysBot.Pokemon.Twitch
                 return true;
             }
 
-            msg = "Unable to legalize the pokemon. Skipping Trade.";
+            msg = "Unable to legalize the Pokémon. Skipping Trade.";
             return false;
         }
 

--- a/SysBot.Pokemon.Twitch/Helpers/TwitchTradeNotifier.cs
+++ b/SysBot.Pokemon.Twitch/Helpers/TwitchTradeNotifier.cs
@@ -41,7 +41,7 @@ namespace SysBot.Pokemon.Twitch
 
         public void TradeFinished(PokeRoutineExecutor routine, PokeTradeDetail<T> info, T result)
         {
-            var message = Data.Species != 0 ? $"Trade finished {Username}. Enjoy your {(Species)Data.Species}!" : "Trade finished. Enjoy your Pokemon!";
+            var message = Data.Species != 0 ? $"Trade finished {Username}. Enjoy your {(Species)Data.Species}!" : "Trade finished. Enjoy your Pokémon!";
             Client.SendMessage(Channel, message);
             OnFinish?.Invoke(routine);
         }
@@ -56,7 +56,7 @@ namespace SysBot.Pokemon.Twitch
         {
             var name = Info.TrainerName;
             var trainer = string.IsNullOrEmpty(name) ? string.Empty : $", {name}";
-            Client.SendWhisper(Username, $"I'm searching for you{trainer}! Use the code you whispered me to search!");
+            Client.SendWhisper(Username, $"I'm waiting for you{trainer}! My IGN is {routine.InGameName}. Use the code you whispered me to search!");
         }
 
         public void SendNotification(PokeRoutineExecutor routine, PokeTradeDetail<T> info, PokeTradeSummary message)

--- a/SysBot.Pokemon/Actions/PokeRoutineExecutor.cs
+++ b/SysBot.Pokemon/Actions/PokeRoutineExecutor.cs
@@ -15,6 +15,7 @@ namespace SysBot.Pokemon
         protected PokeRoutineExecutor(PokeBotConfig cfg) : base(cfg) { }
 
         public LanguageID GameLang;
+        public string InGameName = "SysBot.NET";
 
         public async Task Click(SwitchButton b, int delayMin, int delayMax, CancellationToken token) =>
             await Click(b, Util.Rand.Next(delayMin, delayMax), token).ConfigureAwait(false);
@@ -89,7 +90,8 @@ namespace SysBot.Pokemon
             Connection.Log("Grabbing trainer data of host console...");
             var sav = await GetFakeTrainerSAV(token).ConfigureAwait(false);
             GameLang = (LanguageID)sav.Language;
-            Connection.Name = $"{sav.OT}-{sav.DisplayTID:000000}";
+            InGameName = sav.OT;
+            Connection.Name = $"{InGameName}-{sav.DisplayTID:000000}";
             Connection.Log($"{Connection.IP} identified as {Connection.Name}, using {GameLang}.");
             return sav;
         }
@@ -302,7 +304,7 @@ namespace SysBot.Pokemon
                     Connection.Log("Garbage detected in required Box Slot. Preventing execution.");
                     return;
                 case SlotQuality.HasData:
-                    Connection.Log("Required Box Slot not empty. Move this Pokemon before using the bot!");
+                    Connection.Log("Required Box Slot not empty. Move this Pokémon before using the bot!");
                     Connection.Log(new ShowdownSet(q.Data!).Text);
                     return;
             }

--- a/SysBot.Pokemon/BotTrade/PokeTradeBot.cs
+++ b/SysBot.Pokemon/BotTrade/PokeTradeBot.cs
@@ -317,8 +317,8 @@ namespace SysBot.Pokemon
             // Pokemon in b1s1 is same as the one they were supposed to receive (was never sent).
             if (SearchUtil.HashByDetails(traded) == SearchUtil.HashByDetails(pkm))
                 Connection.Log("User did not complete the trade.");
-            // Pokemon in b1s1 is the same as the one they showed initially, or this is a cloning trade.
-            else if (SearchUtil.HashByDetails(traded) == SearchUtil.HashByDetails(pk) || poke.Type == PokeTradeType.Clone)
+            // As long as we got rid of our inject in b1s1, assume the trade went through.
+            else
             {
                 Connection.Log("User completed the trade.");
                 poke.TradeFinished(this, traded);
@@ -340,8 +340,6 @@ namespace SysBot.Pokemon
                         DumpPokemon(DumpSetting.DumpFolder, "traded", pkm); // sent to partner
                 }
             }
-            else
-                Connection.Log("User did not complete the trade.");
 
             return PokeTradeResult.Success;
         }

--- a/SysBot.Pokemon/FossilBot/FossilBot.cs
+++ b/SysBot.Pokemon/FossilBot/FossilBot.cs
@@ -35,7 +35,7 @@ namespace SysBot.Pokemon
             Connection.Log("Identifying trainer data of the host console.");
             await IdentifyTrainer(token).ConfigureAwait(false);
 
-            Connection.Log("Checking destination slot for revived fossil Pokemon to see if anything is in the slot...");
+            Connection.Log("Checking destination slot for revived fossil Pokémon to see if anything is in the slot...");
             var existing = await GetBoxSlotQuality(InjectBox, InjectSlot, token).ConfigureAwait(false);
             if (existing.Quality != SlotQuality.Overwritable)
             {

--- a/SysBot.Pokemon/TradeHub/PokeTradeHubConfig.cs
+++ b/SysBot.Pokemon/TradeHub/PokeTradeHubConfig.cs
@@ -40,7 +40,7 @@ namespace SysBot.Pokemon
         [Category(FeatureToggle), Description("When set to something other than None, the Random Trades will require this species in addition to the nickname match.")]
         public Species DistributeLedySpecies { get; set; } = Species.Wooloo;
 
-        [Category(FeatureToggle), Description("When enabled, the EggBot will continue to get eggs and dump the Pokemon into the egg dump folder")]
+        [Category(FeatureToggle), Description("When enabled, the EggBot will continue to get eggs and dump the Pokémon into the egg dump folder")]
         public bool ContinueGettingEggs { get; set; } = false;
 
         [Category(FeatureToggle), Description("Link Trade: Using multiple distribution bots -- all bots will confirm their trade code at the same time. When Local, the bots will continue when all are at the barrier. When Remote, something else must signal the bots to continue.")]
@@ -102,7 +102,7 @@ namespace SysBot.Pokemon
         [Category(Metadata), Description("Eggs Retrieved")]
         public int CompletedEggs { get; set; }
 
-        [Category(Metadata), Description("Fossil Pokemon Revived")]
+        [Category(Metadata), Description("Fossil Pokémon Revived")]
         public int CompletedFossils { get; set; }
 
         [Category(Metadata), Description("Raids Completed")]
@@ -201,7 +201,7 @@ namespace SysBot.Pokemon
         /// <summary>
         /// Species of fossil Pokemon to hunt for.
         /// </summary>
-        [Category(FossilPokemon), Description("Species of fossil Pokemon to hunt for.")]
+        [Category(FossilPokemon), Description("Species of fossil Pokémon to hunt for.")]
         public FossilSpecies FossilSpecies { get; set; } = FossilSpecies.Dracozolt;
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace SysBot.Pokemon
         /// <summary>
         /// Toggle for continuing to revive fossils after condition has been met.
         /// </summary>
-        [Category(FossilPokemon), Description("When enabled, the FossilBot will continue to get fossils and dump the Pokemon into the fossil dump folder.")]
+        [Category(FossilPokemon), Description("When enabled, the FossilBot will continue to get fossils and dump the Pokémon into the fossil dump folder.")]
         public bool ContinueGettingFossils { get; set; } = false;
 
         #endregion

--- a/SysBot.Pokemon/Util/Z3SeedResult.cs
+++ b/SysBot.Pokemon/Util/Z3SeedResult.cs
@@ -25,7 +25,7 @@ namespace SysBot.Pokemon
             {
                 Z3SearchResult.SeedMismatch => $"Seed found, but not an exact match {Seed:X16}",
                 Z3SearchResult.Success => string.Join(Environment.NewLine, GetLines()),
-                _ => "The Pokemon is not a raid Pokemon!"
+                _ => "The Pokemon is not a raid Pokémon!"
             };
         }
 


### PR DESCRIPTION
- Reduce user error by clarifying instructions in link trade and notifying user of bot IGN.
- Improve how link trade determines success of trade (and thus dump/counter updates)
- Enables link trade, seed check, and cloning for German language saves
- Added dump to shiny mons shown to Dudu bot
- Standardize formatting of "Pokémon" in text strings