### PR TITLE
Enable dotnet build

### DIFF
--- a/SysBot.Pokemon.ConsoleApp/SysBot.Pokemon.ConsoleApp.csproj
+++ b/SysBot.Pokemon.ConsoleApp/SysBot.Pokemon.ConsoleApp.csproj
@@ -10,12 +10,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <ProjectReference Include="..\SysBot.Pokemon.Discord\SysBot.Pokemon.Discord.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Twitch\SysBot.Pokemon.Twitch.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Z3\SysBot.Pokemon.Z3.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(Configuration)' == 'Release' ">
+    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="Fody" Version="6.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
+++ b/SysBot.Pokemon.WinForms/SysBot.Pokemon.WinForms.csproj
@@ -16,12 +16,13 @@
     <Version>01.00.00</Version>
     <Nullable>enable</Nullable>
     <Platforms>x64;x86</Platforms>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PKHeX.Core" Version="20.4.14" />
-    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,14 @@
     <ProjectReference Include="..\SysBot.Pokemon.Twitch\SysBot.Pokemon.Twitch.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
     <ProjectReference Include="..\SysBot.Pokemon.Z3\SysBot.Pokemon.Z3.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) AND '$(Configuration)' == 'Release' ">
+    <PackageReference Include="Costura.Fody" Version="4.1.0" />
+    <PackageReference Include="Fody" Version="6.0.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
+++ b/SysBot.Pokemon.Z3/SysBot.Pokemon.Z3.csproj
@@ -1,25 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="PKHeX.Core" Version="20.4.14" />
     <ProjectReference Include="..\SysBot.Pokemon\SysBot.Pokemon.csproj" />
   </ItemGroup>
 
-  <!-- x64 specific references -->
-  <ItemGroup Condition=" '$(Platform)' == 'x64' ">
-    <PackageReference Include="Microsoft.Z3.x64" Version="4.8.7" />
-  </ItemGroup>
-
-  <!-- x86 specific references -->
-  <ItemGroup Condition=" '$(Platform)' == 'x86' ">
-    <PackageReference Include="Microsoft.Z3.x86" Version="4.8.7" />
-  </ItemGroup>
+  <Choose>
+    
+    <When Condition=" '$(Platform)' == 'x64' OR $(RuntimeIdentifier.EndsWith('x64')) ">
+      <!-- x64 specific references -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Z3.x64" Version="4.8.7" />
+      </ItemGroup>
+    </When>
+    
+    <Otherwise>
+      <!-- x86 specific references -->
+      <ItemGroup>
+        <PackageReference Include="Microsoft.Z3.x86" Version="4.8.7" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
 </Project>


### PR DESCRIPTION
Fix #64 (Thanks for the inputs!)

Building on Rider now works fine for the entire solution, alongside Visual Studio (I did run it once just to make sure, hopefully I did not miss other configurations breaking!).
I did not put conditions on the resources configuration changes since the [MSBuild suggestion](https://github.com/microsoft/msbuild/issues/4704#issuecomment-530034240) is to always specify them to have a coherent build between .NET and .NET Core.

I also tweaked the conditions for the Microsoft.Z3 package references. By also referencing the RuntimeIdentifier, I am now able to run the following command to create a single executable file with .NET Core:

```
dotnet publish -r win-x64 -c release -f netcoreapp3.1 -p:PublishSingleFile=true -p:PublishTrimmed=true
```

There's also an extra option (`-p:PublishReadyToRun=true`) that makes the executable faster to start, at the expense of larger executable file size.

The .NET Core single file executable is 114MB, or 176MB with "ready to run". I guess I should have expected it since it seems it contains the entire .NET Core runtime...