### PR TITLE
Split on "Ball:" for Showdown sets from Twitch chat

### DIFF
--- a/SysBot.Pokemon/Helpers/TwitchShowdownUtil.cs
+++ b/SysBot.Pokemon/Helpers/TwitchShowdownUtil.cs
@@ -33,7 +33,7 @@ namespace SysBot.Pokemon
 
         private static readonly string[] splittables =
         {
-            "Ability:", "EVs:", "IVs:", "Shiny:", "- ", "Level:", "Happiness:",
+            "Ability:", "EVs:", "IVs:", "Shiny:", "Ball:", "- ", "Level:", "Happiness:",
             "Adamant Nature", "Bashful Nature", "Brave Nature", "Bold Nature", "Calm Nature",
             "Careful Nature", "Docile Nature", "Gentle Nature", "Hardy Nature", "Hasty Nature",
             "Impish Nature", "Jolly Nature", "Lax Nature", "Lonely Nature", "Mild Nature",


### PR DESCRIPTION
Since cc6896ead789ce939545d470a9c3c399777b44b6 , SysBot allows the `Ball:` line in Showdown sets thanks to RegenTemplate.

Discord user `Waltee#6666` noticed that sets from Twitch chat break when trying to use it ; because the parser didn't know to treat it as an independent line.

Note: I'm not super familiar with the different options to know if it might break elsewhere, but I don't think any ability or held item (or other things) are named `Ball:`-something.