### PR TITLE
Fix potential race condition

### DIFF
--- a/SysBot.Pokemon.Discord/SysCord.cs
+++ b/SysBot.Pokemon.Discord/SysCord.cs
@@ -14,12 +14,10 @@ namespace SysBot.Pokemon.Discord
 {
     public static class SysCordInstance
     {
-#pragma warning disable CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
-        public static SysCord Self;
-        public static DiscordManager Manager;
+        public static SysCord Self = default!;
+        public static DiscordManager Manager = default!;
         public static DiscordSettings Settings => Self.Hub.Config.Discord;
-        public static BotRunner<PokeBotConfig> Runner;
-#pragma warning restore CS8618 // Non-nullable field is uninitialized. Consider declaring as nullable.
+        public static BotRunner<PokeBotConfig> Runner = default!;
     }
 
     public sealed class SysCord
@@ -40,7 +38,7 @@ namespace SysBot.Pokemon.Discord
             Hub = hub;
             SysCordInstance.Self = this; // hack
             SysCordInstance.Manager = new DiscordManager(Hub.Config);
-            AutoLegalityWrapper.EnsureInitialized(Hub.Config.Legality);
+            AutoLegalityWrapper.EnsureInitialized(Hub.Config.Legality).Wait();
 
             _client = new DiscordSocketClient(new DiscordSocketConfig
             {

--- a/SysBot.Pokemon.Twitch/TwitchBot.cs
+++ b/SysBot.Pokemon.Twitch/TwitchBot.cs
@@ -29,7 +29,7 @@ namespace SysBot.Pokemon.Twitch
             Settings = settings;
 
             var credentials = new ConnectionCredentials(settings.Username.ToLower(), settings.Token);
-            AutoLegalityWrapper.EnsureInitialized(Hub.Config.Legality);
+            AutoLegalityWrapper.EnsureInitialized(Hub.Config.Legality).Wait();
 
             var clientOptions = new ClientOptions
             {

--- a/SysBot.Pokemon/Helpers/AutoLegalityWrapper.cs
+++ b/SysBot.Pokemon/Helpers/AutoLegalityWrapper.cs
@@ -10,20 +10,24 @@ namespace SysBot.Pokemon
     {
         private static bool Initialized;
 
-        public static void EnsureInitialized(LegalitySettings cfg)
+        public static async Task EnsureInitialized(LegalitySettings cfg)
         {
             if (Initialized)
                 return;
             Initialized = true;
-            InitializeAutoLegality(cfg);
+            await InitializeAutoLegality(cfg).ConfigureAwait(false);
         }
 
-        private static void InitializeAutoLegality(LegalitySettings cfg)
+        private static async Task InitializeAutoLegality(LegalitySettings cfg)
         {
-            Task.Run(InitializeCoreStrings);
-            Task.Run(() => EncounterEvent.RefreshMGDB());
-            InitializeTrainerDatabase(cfg);
-            InitializeSettings(cfg);
+            await Task.WhenAll(
+                Task.Run(() => InitializeCoreStrings()),
+                Task.Run(() => EncounterEvent.RefreshMGDB()),
+                Task.Run(() => InitializeTrainerDatabase(cfg)),
+                Task.Run(() => InitializeSettings(cfg))
+            ).ConfigureAwait(false);
+
+            // Legalizer.AllowBruteForce = false;
         }
 
         private static void InitializeSettings(LegalitySettings cfg)

--- a/SysBot.Tests/GenerateTests.cs
+++ b/SysBot.Tests/GenerateTests.cs
@@ -7,7 +7,7 @@ namespace SysBot.Tests
 {
     public class GenerateTests
     {
-        static GenerateTests() => AutoLegalityWrapper.EnsureInitialized(new LegalitySettings());
+        static GenerateTests() => AutoLegalityWrapper.EnsureInitialized(new LegalitySettings()).Wait();
 
         [Theory]
         [InlineData(Gengar)]
@@ -58,7 +58,8 @@ namespace SysBot.Tests
                 var s = TwitchShowdownUtil.ConvertToShowdown(twitch);
                 var template = s == null ? null : AutoLegalityWrapper.GetTemplate(s);
                 var pk = template == null ? null : sav.GetLegal(template, out _);
-                pk.AbilityNumber.Should().Be(abilNumber);
+                pk.Should().NotBeNull();
+                pk!.AbilityNumber.Should().Be(abilNumber);
             }
         }
 


### PR DESCRIPTION
A fire & forget using Task.Run isn't the best idea. There's no way to tell when the operation completes, and it's entirely up to the whims of the task scheduler when it does complete.

This PR blocks AutoLegalityWrapper.EnsureInitialized on the completion of everything inside it to prevent continuing forward without the MGDB having completed. Unfortunately, all callers of this method are all constructors, so actually awaiting the task isn't an option. Perhaps with future refactoring, you could call this method somewhere outside a constructor, like a Startup.cs file or something, or move towards dependency injection, where each class gets an already-set-up instance of an auto legality wrapper.