### PR TITLE
Fixed "Receiving: None" issue

### DIFF
--- a/SysBot.Pokemon.Discord/Helpers/QueueExtensions.cs
+++ b/SysBot.Pokemon.Discord/Helpers/QueueExtensions.cs
@@ -81,6 +81,8 @@ namespace SysBot.Pokemon.Discord
                 ticketID = $", unique ID: {detail.ID}";
             
             var pokeName = Info.Hub.Config.Discord.DisplayPokeName ? $" Receiving: {(Species)pk8.Species}.": "";
+            if (pokeName.Trim().Equals("Receiving: None."))
+                   pokeName = "";
             msg = $"{user.Mention} - Added to the {type} queue{ticketID}. Current Position: {position.Position}.{pokeName}";
 
             var botct = Info.Hub.Bots.Count;


### PR DESCRIPTION
When the bot receives a command that isn't trade it displays "Receiving: None", instead it should not display the second part of the message.

Before:
![Before](https://user-images.githubusercontent.com/26364966/86899613-8ac19e80-c10a-11ea-8610-a2f1b75bdb12.JPG)

After:
![After](https://user-images.githubusercontent.com/26364966/86899633-91501600-c10a-11ea-9509-fbd3c4a6f957.JPG)
