### PR TITLE
Change Command RunMode to Async

### DIFF
--- a/SysBot.Pokemon.Discord/SysCord.cs
+++ b/SysBot.Pokemon.Discord/SysCord.cs
@@ -54,6 +54,10 @@ namespace SysBot.Pokemon.Discord
             {
                 // Again, log level:
                 LogLevel = LogSeverity.Info,
+                
+                // This makes commands get run on the task thread pool instead on the websocket read thread.
+                // This ensures long running logic can't block the websocket connection.
+                DefaultRunMode = RunMode.Async,
 
                 // There's a few more properties you can set,
                 // for example, case-insensitive commands.


### PR DESCRIPTION
This will make sure the discord websocket read thread can't be blocked by long running commands

I didn't test it yet but looking at the Queue implementation and what the commands do the logic seems to be thread safe