### PR TITLE
Egg bot additional functionality

### DIFF
--- a/SysBot.Pokemon/BotEgg/EggBot.cs
+++ b/SysBot.Pokemon/BotEgg/EggBot.cs
@@ -46,8 +46,6 @@ namespace SysBot.Pokemon
 
         private const int InjectBox = 0;
         private const int InjectSlot = 0;
-
-        public Func<PK8, bool> StopCondition { private get; set; } = pkm => pkm.IsShiny;
         
         private bool StopCondition(PK8 pk)
         {

--- a/SysBot.Pokemon/BotEgg/EggSettings.cs
+++ b/SysBot.Pokemon/BotEgg/EggSettings.cs
@@ -12,8 +12,8 @@ namespace SysBot.Pokemon
         
         /*Creating a new toggle to override the default behavior if the user needs to search for non-shiny eggs*/
         
-        [Category(FeatureToggle), Description("When enabled, the Eggbot will not search for Shiny generated eggs. Use for searching desired natures or IVs")]
-        public bool NoShinyEggs { get; set; } = false;
+        [Category(FeatureToggle), Description("When enabled, the Eggbot will search for any Shiny or Non-Shiny Egg. Use for searching desired natures or IVs")]
+        public bool AnyRandomEgg { get; set; } = false;
         
         /*For Pokemon breeding with optimized conditions, a user might benefit from having select IVs and Nature, which can be easily controlled by the user of the
         Everstone and Destiny Knot Items. These settings are borrowed from EncounterBot settings*/

--- a/SysBot.Pokemon/BotEgg/EggSettings.cs
+++ b/SysBot.Pokemon/BotEgg/EggSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+using PKHeX.Core;
+using System.ComponentModel;
 
 namespace SysBot.Pokemon
 {
@@ -18,10 +19,10 @@ namespace SysBot.Pokemon
         /*For Pokemon breeding with optimized conditions, a user might benefit from having select IVs and Nature, which can be easily controlled by the user of the
         Everstone and Destiny Knot Items. These settings are borrowed from EncounterBot settings*/
         
-        [Category(Encounter), Description("Stop only on Pokémon of the specified nature.")]
+        [Category(FeatureToggle), Description("Stop only on Pokémon of the specified nature.")]
         public Nature DesiredNature { get; set; } = Nature.Random;
 
-        [Category(Encounter), Description("Targets the specified IVs HP/Atk/Def/SpA/SpD/Spe. Matches 0's and 31's, checks min value otherwise. Use \"x\" for unchecked IVs and \"/\" as a separator.")]
+        [Category(FeatureToggle), Description("Targets the specified IVs HP/Atk/Def/SpA/SpD/Spe. Matches 0's and 31's, checks min value otherwise. Use \"x\" for unchecked IVs and \"/\" as a separator.")]
         public string DesiredIVs { get; set; } = "";
     }
 }

--- a/SysBot.Pokemon/BotEgg/EggSettings.cs
+++ b/SysBot.Pokemon/BotEgg/EggSettings.cs
@@ -9,5 +9,14 @@ namespace SysBot.Pokemon
 
         [Category(FeatureToggle), Description("When enabled, the EggBot will continue to get eggs and dump the Pokémon into the egg dump folder")]
         public bool ContinueAfterMatch { get; set; } = false;
+        
+        /*For Pokemon breeding with optimized conditions, a user might benefit from having select IVs and Nature, which can be easily controlled by the user of the
+        Everstone and Destiny Knot Items. These settings are borrowed from EncounterBot settings*/
+        
+        [Category(Encounter), Description("Stop only on Pokémon of the specified nature.")]
+        public Nature DesiredNature { get; set; } = Nature.Random;
+
+        [Category(Encounter), Description("Targets the specified IVs HP/Atk/Def/SpA/SpD/Spe. Matches 0's and 31's, checks min value otherwise. Use \"x\" for unchecked IVs and \"/\" as a separator.")]
+        public string DesiredIVs { get; set; } = "";
     }
 }

--- a/SysBot.Pokemon/BotEgg/EggSettings.cs
+++ b/SysBot.Pokemon/BotEgg/EggSettings.cs
@@ -10,6 +10,11 @@ namespace SysBot.Pokemon
         [Category(FeatureToggle), Description("When enabled, the EggBot will continue to get eggs and dump the Pokémon into the egg dump folder")]
         public bool ContinueAfterMatch { get; set; } = false;
         
+        /*Creating a new toggle to override the default behavior if the user needs to search for non-shiny eggs*/
+        
+        [Category(FeatureToggle), Description("When enabled, the Eggbot will not search for Shiny generated eggs. Use for searching desired natures or IVs")]
+        public bool NoShinyEggs { get; set; } = false;
+        
         /*For Pokemon breeding with optimized conditions, a user might benefit from having select IVs and Nature, which can be easily controlled by the user of the
         Everstone and Destiny Knot Items. These settings are borrowed from EncounterBot settings*/
         


### PR DESCRIPTION
Hi there; I have been using the EggBot extensively on my end, and thought to myself that it might be a benefit to the end-user if similar functionality in the EncounterBot was used. I would like to propose the implementation of searching Desired Natures and IVs for Pokemon fetched in the Day Care Center, with the added option to get eggs that may or may not be Shiny.


I am not sure if this feature would be approved, but I thought at the least it would be a great initiative on my part to go ahead and write up the foundation of the feature. Otherwise, I would be happy to reach out to someone currently developing SysBOT.Net to see if there is a better way to communicate the feature.


I hope this is helpful to the application!