### PR TITLE
Remote bot reconnect if a disconnect occurs

### DIFF
--- a/SysBot.Base/Connection/SwitchConnectionBase.cs
+++ b/SysBot.Base/Connection/SwitchConnectionBase.cs
@@ -4,7 +4,7 @@ namespace SysBot.Base
 {
     public abstract class SwitchConnectionBase
     {
-        public readonly Socket Connection = new Socket(SocketType.Stream, ProtocolType.Tcp);
+        public Socket Connection = new Socket(SocketType.Stream, ProtocolType.Tcp);
         public readonly string IP;
         public readonly int Port;
 

--- a/SysBot.Pokemon.Discord/Commands/Management/BotModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Management/BotModule.cs
@@ -95,5 +95,26 @@ namespace SysBot.Pokemon.Discord
             bot.Bot.Config.Initialize(task);
             await Context.Channel.EchoAndReply($"The bot at {ip} ({bot.Bot.Connection.Name}) has been commanded to do {task} as its next task.").ConfigureAwait(false);
         }
+
+        [Command("botRestart")]
+        [Summary("Restarts the bot(s) by IP address(es), separated by commas.")]
+        [RequireSudo]
+        public async Task RestartBotAsync(string ip)
+        {
+            string[] ips = ip.Split(',');
+            for (int i = 0; i < ips.Length; i++)
+            {
+                var bot = SysCordInstance.Runner.GetBot(ips[i]);
+                if (bot == null)
+                {
+                    await ReplyAsync($"No bot has that IP address ({ips[i]}).").ConfigureAwait(false);
+                    return;
+                }
+
+                bot.Bot.Connection.Reset(ips[i]);
+                bot.Start();
+                await Context.Channel.EchoAndReply($"The bot at {ips[i]} ({bot.Bot.Connection.Name}) has been commanded to start.").ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/SysBot.Pokemon.Discord/SysCord.cs
+++ b/SysBot.Pokemon.Discord/SysCord.cs
@@ -263,6 +263,9 @@ namespace SysBot.Pokemon.Discord
                     await _client.SetStatusAsync(state).ConfigureAwait(false);
                 }
                 await Task.Delay(gap, token).ConfigureAwait(false);
+
+                if (_client.ConnectionState == ConnectionState.Disconnected)
+                    await MainAsync(Hub.Config.Discord.Token, token).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Adds remote command to reconnect bots after internet outages, attempts to reconnect to Discord on disconnect so we could send a command in the first place.

Submitting for review in case you'd like to include this function to the main repo. Connection.Connect(IP, Port) still used to set up the initial connection. Afterwards have to use BeginConnect in order to properly reconnect to a socket.