### PR TITLE
WinForms option for restarting connection, handle bot StopCondition disconnect

### DIFF
--- a/SysBot.Base/Connection/SwitchConnectionAsync.cs
+++ b/SysBot.Base/Connection/SwitchConnectionAsync.cs
@@ -30,7 +30,9 @@ namespace SysBot.Base
 
         public void Reset(string ip)
         {
-            Disconnect();
+            if (Connected)
+                Disconnect();
+
             Connection = new Socket(SocketType.Stream, ProtocolType.Tcp);
             Log("Connecting to device...");
             var address = Dns.GetHostAddresses(ip);

--- a/SysBot.Pokemon.WinForms/Controls/BotController.cs
+++ b/SysBot.Pokemon.WinForms/Controls/BotController.cs
@@ -151,6 +151,18 @@ namespace SysBot.Pokemon.WinForms
                 case BotControlCommand.Start: bot.Start(); break;
                 case BotControlCommand.Stop: bot.Stop(); break;
                 case BotControlCommand.Resume: bot.Resume(); break;
+                case BotControlCommand.Restart:
+                    {
+                        DialogResult promptResult; 
+                        promptResult = MessageBox.Show("Are you sure you want to restart the connection?", "Warning", MessageBoxButtons.YesNo); 
+                        if (promptResult == DialogResult.Yes)
+                        {
+                            bot.Bot.Connection.Reset(bot.Bot.Config.IP);
+                            bot.Start();
+                        }
+                        else return;
+                    };
+                    break;
                 default:
                     WinFormsUtil.Alert($"{cmd} is not a command that can be sent to the Bot.");
                     return;
@@ -195,6 +207,7 @@ namespace SysBot.Pokemon.WinForms
         Stop,
         Idle,
         Resume,
+        Restart,
     }
 
     public static class BotControlCommandExtensions
@@ -207,6 +220,7 @@ namespace SysBot.Pokemon.WinForms
                 BotControlCommand.Stop => running,
                 BotControlCommand.Idle => running && !paused,
                 BotControlCommand.Resume => paused,
+                BotControlCommand.Restart => true,
                 _ => false,
             };
         }

--- a/SysBot.Pokemon.WinForms/Controls/BotController.cs
+++ b/SysBot.Pokemon.WinForms/Controls/BotController.cs
@@ -152,17 +152,15 @@ namespace SysBot.Pokemon.WinForms
                 case BotControlCommand.Stop: bot.Stop(); break;
                 case BotControlCommand.Resume: bot.Resume(); break;
                 case BotControlCommand.Restart:
-                    {
-                        DialogResult promptResult; 
-                        promptResult = MessageBox.Show("Are you sure you want to restart the connection?", "Warning", MessageBoxButtons.YesNo); 
-                        if (promptResult == DialogResult.Yes)
-                        {
-                            bot.Bot.Connection.Reset(bot.Bot.Config.IP);
-                            bot.Start();
-                        }
-                        else return;
-                    };
+                {
+                    var prompt = WinFormsUtil.Prompt(MessageBoxButtons.YesNo, "Are you sure you want to restart the connection?");
+                    if (prompt != DialogResult.Yes)
+                        return;
+
+                    bot.Bot.Connection.Reset(bot.Bot.Config.IP);
+                    bot.Start();
                     break;
+                }
                 default:
                     WinFormsUtil.Alert($"{cmd} is not a command that can be sent to the Bot.");
                     return;


### PR DESCRIPTION
Add right-click option (with a Yes/No prompt) to restart a bot from the client.

Check if "Connected == true" before we call Disconnect(). Since StopCondition(pk) for various bots already calls the Disconnect() method, we don't need to do it again as it's already disconnected. Meanwhile internet outages will not update the "Connected" flag. Could instead trycatch "Connection.Shutdown(SocketShutdown.Both)" but adds more complexity for minimal gain, if any.