### PR TITLE
usb-botbase large read/write, GetMainNsoBase, and GetHeapBase fix

### DIFF
--- a/SysBot.Base/Connection/Switch/USB/SwitchUSB.cs
+++ b/SysBot.Base/Connection/Switch/USB/SwitchUSB.cs
@@ -122,23 +122,21 @@ namespace SysBot.Base
                 return ReadInternal(buffer);
         }
 
-        public byte[] Read(uint offset, int length)
+        protected byte[] Read(ulong offset, int length, Func<ulong, int, byte[]> method)
         {
-            var method = SwitchOffsetType.Heap.GetReadMethod(false);
             if (length > MaximumTransferSize)
                 return ReadLarge(offset, length, method);
-            return Read(offset, length, method);
+            return ReadSmall(offset, length, method);
         }
 
-        public void Write(byte[] data, uint offset)
+        protected void Write(byte[] data, ulong offset, Func<ulong, byte[], byte[]> method)
         {
-            var method = SwitchOffsetType.Heap.GetWriteMethod(false);
             if (data.Length > MaximumTransferSize)
                 WriteLarge(data, offset, method);
-            Write(data, offset, method);
+            else WriteSmall(data, offset, method);
         }
 
-        protected byte[] Read(ulong offset, int length, Func<ulong, int, byte[]> method)
+        public byte[] ReadSmall(ulong offset, int length, Func<ulong, int, byte[]> method)
         {
             lock (_sync)
             {
@@ -152,7 +150,7 @@ namespace SysBot.Base
             }
         }
 
-        protected void Write(byte[] data, ulong offset, Func<ulong, byte[], byte[]> method)
+        public void WriteSmall(byte[] data, ulong offset, Func<ulong, byte[], byte[]> method)
         {
             lock (_sync)
             {
@@ -194,7 +192,7 @@ namespace SysBot.Base
             return l;
         }
 
-        private void WriteLarge(byte[] data, uint offset, Func<ulong, byte[], byte[]> method)
+        private void WriteLarge(byte[] data, ulong offset, Func<ulong, byte[], byte[]> method)
         {
             int byteCount = data.Length;
             for (int i = 0; i < byteCount; i += MaximumTransferSize)
@@ -205,7 +203,7 @@ namespace SysBot.Base
             }
         }
 
-        private byte[] ReadLarge(uint offset, int length, Func<ulong, int, byte[]> method)
+        private byte[] ReadLarge(ulong offset, int length, Func<ulong, int, byte[]> method)
         {
             var result = new byte[length];
             for (int i = 0; i < length; i += MaximumTransferSize)
@@ -223,7 +221,7 @@ namespace SysBot.Base
             {
                 var buffer = new byte[(length * 2) + 0];
                 var _ = Read(buffer);
-                return Decoder.ConvertHexByteStringToBytes(buffer);
+                return buffer;
             }
         }
     }

--- a/SysBot.Base/Connection/Switch/USB/SwitchUSBAsync.cs
+++ b/SysBot.Base/Connection/Switch/USB/SwitchUSBAsync.cs
@@ -38,7 +38,6 @@ namespace SysBot.Base
             {
                 Send(SwitchCommand.GetMainNsoBase(false));
                 byte[] baseBytes = ReadResponse(8);
-                Array.Reverse(baseBytes, 0, 8);
                 return BitConverter.ToUInt64(baseBytes, 0);
             }, token);
         }
@@ -49,7 +48,6 @@ namespace SysBot.Base
             {
                 Send(SwitchCommand.GetHeapBase(false));
                 byte[] baseBytes = ReadResponse(8);
-                Array.Reverse(baseBytes, 0, 8);
                 return BitConverter.ToUInt64(baseBytes, 0);
             }, token);
         }

--- a/SysBot.Base/Connection/Switch/USB/SwitchUSBSync.cs
+++ b/SysBot.Base/Connection/Switch/USB/SwitchUSBSync.cs
@@ -27,7 +27,6 @@ namespace SysBot.Base
         {
             Send(SwitchCommand.GetMainNsoBase(false));
             byte[] baseBytes = ReadResponse(8);
-            Array.Reverse(baseBytes, 0, 8);
             return BitConverter.ToUInt64(baseBytes, 0);
         }
 
@@ -35,7 +34,6 @@ namespace SysBot.Base
         {
             Send(SwitchCommand.GetHeapBase(false));
             byte[] baseBytes = ReadResponse(8);
-            Array.Reverse(baseBytes, 0, 8);
             return BitConverter.ToUInt64(baseBytes, 0);
         }
     }


### PR DESCRIPTION
- USB-Botbase's usb response returns ready-to-use byte arrays. As such, we do not need to decode or reverse the returned array.
- By default, SysBot calls read and write methods that do not take maximum transfer size into account. While we currently are not doing any large reads or writes for this to be a problem, changing which methods are implemented by connection interfaces should prevent this as a potential issue in the future.