### PR TITLE
USB-Botbase compatibility:

### DIFF
--- a/SysBot.Base/Connection/Switch/ISwitchConnectionAsync.cs
+++ b/SysBot.Base/Connection/Switch/ISwitchConnectionAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace SysBot.Base
 {
@@ -10,6 +11,7 @@ namespace SysBot.Base
     {
         Task<ulong> GetMainNsoBaseAsync(CancellationToken token);
         Task<ulong> GetHeapBaseAsync(CancellationToken token);
+        Task<string> GetTitleID(CancellationToken token);
 
         Task<byte[]> ReadBytesMainAsync(ulong offset, int length, CancellationToken token);
         Task<byte[]> ReadBytesAbsoluteAsync(ulong offset, int length, CancellationToken token);
@@ -19,5 +21,9 @@ namespace SysBot.Base
 
         Task<byte[]> ReadRaw(byte[] command, int length, CancellationToken token);
         Task SendRaw(byte[] command, CancellationToken token);
+
+        Task<byte[]> PointerPeek(int size, IEnumerable<long> jumps, CancellationToken token);
+        Task<ulong> PointerAll(IEnumerable<long> jumps, CancellationToken token);
+        Task<ulong> PointerRelative(IEnumerable<long> jumps, CancellationToken token);
     }
 }

--- a/SysBot.Base/Connection/Switch/USB/SwitchUSBSync.cs
+++ b/SysBot.Base/Connection/Switch/USB/SwitchUSBSync.cs
@@ -26,14 +26,14 @@ namespace SysBot.Base
         public ulong GetMainNsoBase()
         {
             Send(SwitchCommand.GetMainNsoBase(false));
-            byte[] baseBytes = ReadResponse(8);
+            byte[] baseBytes = ReadBulkUSB();
             return BitConverter.ToUInt64(baseBytes, 0);
         }
 
         public ulong GetHeapBase()
         {
             Send(SwitchCommand.GetHeapBase(false));
-            byte[] baseBytes = ReadResponse(8);
+            byte[] baseBytes = ReadBulkUSB();
             return BitConverter.ToUInt64(baseBytes, 0);
         }
     }

--- a/SysBot.Pokemon/Actions/PokeRoutineExecutor.cs
+++ b/SysBot.Pokemon/Actions/PokeRoutineExecutor.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using PKHeX.Core;
+﻿using PKHeX.Core;
 using SysBot.Base;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace SysBot.Pokemon
 {
@@ -51,18 +48,8 @@ namespace SysBot.Pokemon
 
         protected async Task<(bool, ulong)> ValidatePointerAll(IEnumerable<long> jumps, CancellationToken token)
         {
-            var solved = await PointerAll(jumps, token).ConfigureAwait(false);
+            var solved = await SwitchConnection.PointerAll(jumps, token).ConfigureAwait(false);
             return (solved != 0, solved);
-        }
-
-        protected async Task<ulong> PointerAll(IEnumerable<long> jumps, CancellationToken token)
-        {
-            byte[] command = Encoding.UTF8.GetBytes($"pointerAll{string.Concat(jumps.Select(z => $" {z}"))}\r\n");
-            byte[] socketReturn = await SwitchConnection.ReadRaw(command, (sizeof(ulong) * 2) + 1, token).ConfigureAwait(false);
-            var bytes = Base.Decoder.ConvertHexByteStringToBytes(socketReturn);
-            Array.Reverse(bytes);
-
-            return BitConverter.ToUInt64(bytes, 0);
         }
 
         public static void DumpPokemon(string folder, string subfolder, T pk)

--- a/SysBot.Pokemon/BDSP/BotTrade/PokeTradeBotBS.cs
+++ b/SysBot.Pokemon/BDSP/BotTrade/PokeTradeBotBS.cs
@@ -292,7 +292,7 @@ namespace SysBot.Pokemon
 
             var offered = await ReadUntilPresentPointer(Offsets.LinkTradePartnerPokemonPointer, 25_000, 1_000, BoxFormatSlotSize, token).ConfigureAwait(false);
 
-            var offset = await PointerAll(Offsets.LinkTradePartnerPokemonPointer, token).ConfigureAwait(false);
+            var offset = await SwitchConnection.PointerAll(Offsets.LinkTradePartnerPokemonPointer, token).ConfigureAwait(false);
             var oldEC = await SwitchConnection.ReadBytesAbsoluteAsync(offset, 4, token).ConfigureAwait(false);
             if (offered is null)
                 return PokeTradeResult.TrainerTooSlow;
@@ -480,13 +480,13 @@ namespace SysBot.Pokemon
         private async Task InitializeSessionOffsets(CancellationToken token)
         {
             Log("Caching session offsets...");
-            BoxStartOffset = await PointerAll(Offsets.BoxStartPokemonPointer, token).ConfigureAwait(false);
+            BoxStartOffset = await SwitchConnection.PointerAll(Offsets.BoxStartPokemonPointer, token).ConfigureAwait(false);
             await Task.Delay(1_000).ConfigureAwait(false);
-            UnionGamingOffset = await PointerAll(Offsets.UnionWorkIsGamingPointer, token).ConfigureAwait(false);
+            UnionGamingOffset = await SwitchConnection.PointerAll(Offsets.UnionWorkIsGamingPointer, token).ConfigureAwait(false);
             await Task.Delay(1_000).ConfigureAwait(false);
-            UnionTalkingOffset = await PointerAll(Offsets.UnionWorkIsTalkingPointer, token).ConfigureAwait(false);
+            UnionTalkingOffset = await SwitchConnection.PointerAll(Offsets.UnionWorkIsTalkingPointer, token).ConfigureAwait(false);
             await Task.Delay(1_000).ConfigureAwait(false);
-            SoftBanOffset = await PointerAll(Offsets.UnionWorkPenaltyPointer, token).ConfigureAwait(false);
+            SoftBanOffset = await SwitchConnection.PointerAll(Offsets.UnionWorkPenaltyPointer, token).ConfigureAwait(false);
             await Task.Delay(1_000).ConfigureAwait(false);
         }
 
@@ -579,7 +579,7 @@ namespace SysBot.Pokemon
             var start = DateTime.Now;
             var pkprev = new PB8();
 
-            var offset = await PointerAll(Offsets.LinkTradePartnerPokemonPointer, token).ConfigureAwait(false);
+            var offset = await SwitchConnection.PointerAll(Offsets.LinkTradePartnerPokemonPointer, token).ConfigureAwait(false);
 
             while (ctr < Hub.Config.Trade.MaxDumpsPerTrade && DateTime.Now - start < time)
             {
@@ -617,8 +617,8 @@ namespace SysBot.Pokemon
 
         private async Task<TradePartnerBS> GetTradePartnerInfo(CancellationToken token)
         {
-            var id = await PointerPeek(4, Offsets.LinkTradePartnerIDPointer, token).ConfigureAwait(false);
-            var name = await PointerPeek(TradePartnerBS.MaxByteLengthStringObject, Offsets.LinkTradePartnerNamePointer, token).ConfigureAwait(false);
+            var id = await SwitchConnection.PointerPeek(4, Offsets.LinkTradePartnerIDPointer, token).ConfigureAwait(false);
+            var name = await SwitchConnection.PointerPeek(TradePartnerBS.MaxByteLengthStringObject, Offsets.LinkTradePartnerNamePointer, token).ConfigureAwait(false);
             return new TradePartnerBS(id, name);
         }
 


### PR DESCRIPTION
 - Similarly to LiveHex, consolidate USB read methods into one. Allow usb-botbase to tell us the return size, keep reading until we're done.
 - Move certain methods used by BDSP to a shared interface (usb-botbase needs separate handling as it does not return strings).