### PR TITLE
Add MarkMatch setting, allowing for searching for specific marks

### DIFF
--- a/SysBot.Pokemon/Settings/StopConditionSettings.cs
+++ b/SysBot.Pokemon/Settings/StopConditionSettings.cs
@@ -30,6 +30,9 @@ namespace SysBot.Pokemon
         [Category(StopConditions), Description("Stop only on Pokémon that have a mark.")]
         public bool MarkOnly { get; set; } = false;
 
+        [Category(StopConditions), Description("If MarkOnly is true, stop only on Pokémon with this specific mark.")]
+        public Mark MarkMatch { get; set; } = Mark.Any;
+
         [Category(StopConditions), Description("Holds Capture button to record a 30 second clip when a matching Pokémon is found by EncounterBot or Fossilbot.")]
         public bool CaptureVideoClip { get; set; }
 
@@ -54,7 +57,7 @@ namespace SysBot.Pokemon
             if (settings.TargetNature != Nature.Random && settings.TargetNature != (Nature)pk.Nature)
                 return false;
 
-            if (settings.MarkOnly && pk is IRibbonIndex m && !HasMark(m))
+            if (settings.MarkOnly && pk is IRibbonIndex m && (settings.MarkMatch == Mark.Any ? !HasMark(m) : !HasMark(m, settings.MarkMatch)))
                 return false;
 
             if (settings.ShinyTarget != TargetShinyType.DisableOption)
@@ -128,6 +131,61 @@ namespace SysBot.Pokemon
                     return true;
             }
             return false;
+        }
+
+        private static bool HasMark(IRibbonIndex pk, Mark m)
+        {
+            return pk.GetRibbon((int)m);
+        }
+
+        public enum Mark
+        {
+            Any = 0,
+            Lunchtime = 53,
+            SleepyTime = 54,
+            Dusk = 55,
+            Dawn = 56,
+            Cloudy = 57,
+            Rainy = 58,
+            Stormy = 59,
+            Snowy = 60,
+            Blizzard = 61,
+            Dry = 62,
+            Sandstorm = 63,
+            Misty = 64,
+            //Destiny = 65,     // Not obtainable
+            //Fishing = 66,     // Fishing spawns only (encounterbot doesn't handle these)
+            //Curry = 67,       // Curry spawns only (encounterbot doesn't handle these)
+            Uncommon = 68,
+            Rare = 69,
+            Rowdy = 70,
+            AbsentMinded = 71,
+            Jittery = 72,
+            Excited = 73,
+            Charismatic = 74,
+            Calmness = 75,
+            Intense = 76,
+            ZonedOut = 77,
+            Joyful = 78,
+            Angry = 79,
+            Smiley = 80,
+            Teary = 81,
+            Upbeat = 82,
+            Peeved = 83,
+            Intellectual = 84,
+            Ferocious = 85,
+            Crafty = 86,
+            Scowling = 87,
+            Kindly = 88,
+            Flustered = 89,
+            PumpedUp = 90,
+            ZeroEnergy = 91,
+            Prideful = 92,
+            Unsure = 93,
+            Humble = 94,
+            Thorny = 95,
+            Vigor = 96,
+            Slump = 97
         }
 
         public string GetPrintName(PKM pk)


### PR DESCRIPTION
Adds a list of Marks to be used for the Encounter bot when HasMark is set to true. Does not include marks that are unobtainable by any current SysBot functions (Destiny, Fishing, Curry)