### PR TITLE
Basic trainer data validation and Discord permissions check.

### DIFF
--- a/SysBot.Pokemon/Actions/PokeRoutineExecutorBase.cs
+++ b/SysBot.Pokemon/Actions/PokeRoutineExecutorBase.cs
@@ -33,6 +33,8 @@ namespace SysBot.Pokemon
             Log($"{Connection.Name} identified as {Connection.Label}, using {GameLang}.");
         }
 
+        protected bool IsValidTrainerData() => GameLang > LanguageID.Hacked && GameLang <= LanguageID.ChineseT && InGameName.Length > 0 && Version > 0;
+
         public override void SoftStop() => Config.Pause();
 
         public async Task Click(SwitchButton b, int delayMin, int delayMax, CancellationToken token) =>

--- a/SysBot.Pokemon/BDSP/PokeRoutineExecutor8BS.cs
+++ b/SysBot.Pokemon/BDSP/PokeRoutineExecutor8BS.cs
@@ -74,8 +74,10 @@ namespace SysBot.Pokemon
             var sav = await GetFakeTrainerSAV(token).ConfigureAwait(false);
             InitSaveData(sav);
 
-            if (await GetTextSpeed(token).ConfigureAwait(false) != TextSpeedOption.Fast)
-                Log("Text speed should be set to FAST. Stop the bot and fix this if you encounter problems.");
+            if (!IsValidTrainerData())
+                throw new Exception("Trainer data is not valid. Refer to the SysBot.NET wiki for bad or no trainer data.");
+            if (await GetTextSpeed(token).ConfigureAwait(false) < TextSpeedOption.Fast)
+                throw new Exception("Text speed should be set to FAST. Fix this for correct operation.");
 
             return sav;
         }

--- a/SysBot.Pokemon/SWSH/PokeRoutineExecutor8.cs
+++ b/SysBot.Pokemon/SWSH/PokeRoutineExecutor8.cs
@@ -84,8 +84,10 @@ namespace SysBot.Pokemon
             var sav = await GetFakeTrainerSAV(token).ConfigureAwait(false);
             InitSaveData(sav);
 
-            if (await GetTextSpeed(token).ConfigureAwait(false) != TextSpeedOption.Fast)
-                Log("Text speed should be set to FAST. Stop the bot and fix this if you encounter problems.");
+            if (!IsValidTrainerData())
+                throw new Exception("Trainer data is not valid. Refer to the SysBot.NET wiki for bad or no trainer data.");
+            if (await GetTextSpeed(token).ConfigureAwait(false) < TextSpeedOption.Fast)
+                throw new Exception("Text speed should be set to FAST. Fix this for correct operation.");
 
             return sav;
         }


### PR DESCRIPTION
- Check if trainer data is valid in addition to text speed when first initializing.
- Change text speed validation to account for instant text.
- Throw if either one doesn't pass.
- If an Http exception is thrown when attempting to delete a message, only ping bot owner if "manage messages" permissions are missing. Otherwise reply with an error message.