### PR TITLE
Fix incorrect generic type usage in RecordUtil for PokeTradeBot classes

### DIFF
--- a/SysBot.Pokemon/BDSP/BotTrade/PokeTradeBotBS.cs
+++ b/SysBot.Pokemon/BDSP/BotTrade/PokeTradeBotBS.cs
@@ -279,7 +279,7 @@ public class PokeTradeBotBS(PokeTradeHub<PB8> Hub, PokeBotState Config) : PokeRo
 
         var tradePartner = await GetTradePartnerInfo(token).ConfigureAwait(false);
         var trainerNID = GetFakeNID(tradePartner.TrainerName, tradePartner.TrainerID);
-        RecordUtil<PokeTradeBotSWSH>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
+        RecordUtil<PokeTradeBotBS>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
         Log($"Found Link Trade partner: {tradePartner.TrainerName}-{tradePartner.TID7} (ID: {trainerNID}");
 
         var partnerCheck = await CheckPartnerReputation(this, poke, trainerNID, tradePartner.TrainerName, AbuseSettings, token);

--- a/SysBot.Pokemon/LA/BotTrade/PokeTradeBotLA.cs
+++ b/SysBot.Pokemon/LA/BotTrade/PokeTradeBotLA.cs
@@ -272,7 +272,7 @@ public class PokeTradeBotLA(PokeTradeHub<PA8> Hub, PokeBotState Config) : PokeRo
 
         var tradePartner = await GetTradePartnerInfo(token).ConfigureAwait(false);
         var trainerNID = await GetTradePartnerNID(TradePartnerNIDOffset, token).ConfigureAwait(false);
-        RecordUtil<PokeTradeBotSWSH>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
+        RecordUtil<PokeTradeBotLA>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
         Log($"Found Link Trade partner: {tradePartner.TrainerName}-{tradePartner.TID7} (ID: {trainerNID})");
 
         var partnerCheck = await CheckPartnerReputation(this, poke, trainerNID, tradePartner.TrainerName, AbuseSettings, token);

--- a/SysBot.Pokemon/SV/BotTrade/PokeTradeBotSV.cs
+++ b/SysBot.Pokemon/SV/BotTrade/PokeTradeBotSV.cs
@@ -326,7 +326,7 @@ public class PokeTradeBotSV(PokeTradeHub<PK9> Hub, PokeBotState Config) : PokeRo
 
         var tradePartner = await GetTradePartnerInfo(token).ConfigureAwait(false);
         var trainerNID = await GetTradePartnerNID(TradePartnerNIDOffset, token).ConfigureAwait(false);
-        RecordUtil<PokeTradeBotSWSH>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
+        RecordUtil<PokeTradeBotSV>.Record($"Initiating\t{trainerNID:X16}\t{tradePartner.TrainerName}\t{poke.Trainer.TrainerName}\t{poke.Trainer.ID}\t{poke.ID}\t{toSend.EncryptionConstant:X8}");
         Log($"Found Link Trade partner: {tradePartner.TrainerName}-{tradePartner.TID7} (ID: {trainerNID})");
 
         var partnerCheck = await CheckPartnerReputation(this, poke, trainerNID, tradePartner.TrainerName, AbuseSettings, token);


### PR DESCRIPTION
**Description**:

The following classes, which handle trade functionality for different Pokémon games, use the generic `RecordUtil<PokeTradeBotSWSH>`:

- **[PokeTradeBotLA](https://github.com/kwsch/SysBot.NET/blob/42c208d9967853e4f4552c36aa6395c1914654e4/SysBot.Pokemon/LA/BotTrade/PokeTradeBotLA.cs#L275)**
- **[PokeTradeBotSV](https://github.com/kwsch/SysBot.NET/blob/42c208d9967853e4f4552c36aa6395c1914654e4/SysBot.Pokemon/SV/BotTrade/PokeTradeBotSV.cs#L329)**
- **[PokeTradeBotBS](https://github.com/kwsch/SysBot.NET/blob/42c208d9967853e4f4552c36aa6395c1914654e4/SysBot.Pokemon/BDSP/BotTrade/PokeTradeBotBS.cs#L282)**

These classes are intended for handling trades in Pokémon Legends: Arceus (**LA**), Pokémon Scarlet and Violet (**SV**), and Pokémon Brilliant Diamond and Shining Pearl (**BDSP**). However, they use the generic type `PokeTradeBotSWSH`, which is specific to Pokémon Sword and Shield (**SWSH**).

This raises the following concerns:
1. **Incorrect Class Association**: The generic type `PokeTradeBotSWSH` does not align with the respective games these classes are designed for.
2. **Potential Code Mismanagement**: This could lead to confusion or unintended behavior if specific game-related logic is required within `RecordUtil` or its related components.
3. **Code Consistency**: Each trade bot class should use a generic type that reflects its respective game (e.g., `PokeTradeBotLA`, `PokeTradeBotSV`, or `PokeTradeBotBS`).

**Proposed Solution**:
- Update the generic type in the `RecordUtil` usage within each class to match the respective game's trade bot class:
  - Change `RecordUtil<PokeTradeBotSWSH>` in `PokeTradeBotLA` to `RecordUtil<PokeTradeBotLA>`.
  - Change `RecordUtil<PokeTradeBotSWSH>` in `PokeTradeBotSV` to `RecordUtil<PokeTradeBotSV>`.
  - Change `RecordUtil<PokeTradeBotSWSH>` in `PokeTradeBotBS` to `RecordUtil<PokeTradeBotBS>`.

This change will ensure clarity, consistency, and correctness across the codebase.

Let me know if further clarification is needed! Thank you for maintaining such an excellent project. 😊