### PR TITLE
Add support for Linux using usb-botbase

### DIFF
--- a/SysBot.Base/Connection/Switch/USB/SwitchUSB.cs
+++ b/SysBot.Base/Connection/Switch/USB/SwitchUSB.cs
@@ -2,6 +2,7 @@ using LibUsbDotNet;
 using LibUsbDotNet.Main;
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace SysBot.Base;
@@ -53,7 +54,8 @@ public abstract class SwitchUSB : IConsoleConnection
 
         lock (_sync)
         {
-            if (!usb.UsbRegistryInfo.IsAlive)
+            // UsbRegistryInfo is only supported on Windows.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !usb.UsbRegistryInfo!.IsAlive)
                 usb.ResetDevice();
 
             if (usb.IsOpen)
@@ -86,9 +88,13 @@ public abstract class SwitchUSB : IConsoleConnection
                 if (ur.Pid != 0x3000)
                     continue;
 
-                ur.DeviceProperties.TryGetValue("Address", out var addr);
-                if (Port.ToString() != addr?.ToString())
-                    continue;
+                // Only Windows supports reading the port number from the registry.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    ur.DeviceProperties.TryGetValue("Address", out var addr);
+                    if (Port.ToString() != addr?.ToString())
+                        continue;
+                }
 
                 return ur.Device;
             }


### PR DESCRIPTION
Added Windows-specific runtime checks to enable usb-botbase functionality on Linux systems. The changes wrap Windows-only USB registry operations (UsbRegistryInfo and device address lookup) with `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` checks.

With these minor changes, I'm able to run this using usb-botbase on a Linux machine.