### PR TITLE
Add support for local trade on Scarlet and Violet

### DIFF
--- a/SysBot.Pokemon/Settings/TradeSettings.cs
+++ b/SysBot.Pokemon/Settings/TradeSettings.cs
@@ -44,6 +44,9 @@ public class TradeSettings : IBotStateSettings, ICountSettings
     [Category(TradeConfig), Description("When enabled, disallows requesting Pokémon if they have a HOME Tracker.")]
     public bool DisallowTracked { get; set; } = true;
 
+    [Category(TradeConfig), Description("When enabled, the internet connection step will be skipped during normal bot loop operation. If already connected, the bot will disconnect from online. Applies only to Scarlet and Violet, and only when running in USB mode.")]
+    public bool PerformLocalTradeSV { get; set; } = false;
+
     /// <summary>
     /// Gets a random trade code based on the range settings.
     /// </summary>


### PR DESCRIPTION
These changes add support for local trade on Scarlet and Violet.

This feature can be configured using the newly added property "PerformLocalTradeSV", which can be found in the "Trade" section.

As stated in the property description, this feature only works when the bot controls the Nintendo Switch via the USB protocol. If the console is connected via Wi-Fi, the bot will still attempt to connect to the internet, as an attempt to locally communicate with another system would break the connection to SysBot.

If the current configuration allows a local trade to work (property set to True and using the USB protocol) but the Nintendo Switch is currently connected online, the bot will first attempt to disconnect before starting the local trade.