### PR TITLE
Fix SwSh SetBoxPokemon

### DIFF
--- a/SysBot.Pokemon/SWSH/PokeRoutineExecutor8SWSH.cs
+++ b/SysBot.Pokemon/SWSH/PokeRoutineExecutor8SWSH.cs
@@ -53,7 +53,7 @@ public abstract class PokeRoutineExecutor8SWSH(PokeBotState Config) : PokeRoutin
         pkm.ResetPartyStats();
         Span<byte> data = stackalloc byte[pkm.SIZE_PARTY];
         pkm.WriteEncryptedDataParty(data);
-        return SwitchConnection.WriteBytesAbsoluteAsync(data, offset, token);
+        return SwitchConnection.WriteBytesAsync(data.ToArray(), offset, token);
     }
 
     public override Task<PK8> ReadBoxPokemon(int box, int slot, CancellationToken token)


### PR DESCRIPTION
Latest commits introduced a minor issue when writing a Pokémon in Sword/Shield. As shown in the screenshot, the Pokémon is now written to an absolute address instead of the heap, this results in writing to an invalid/casual memory space, causing the Pokémon to not be traded.
<img width="1012" height="422" alt="immagine" src="https://github.com/user-attachments/assets/da6ca4be-771c-4b92-892e-e358817adcd3" />
I chose not to modify the method `WriteBytesAsync(byte[] data...)` to `WriteBytesAsync(Span<byte> data...)`, as the existing sig is still used in many places, both within this main repo and external projects. It may be worth considering aligning the method with the newer changes and introducing `Span` as well, but that's not a decision for me to make.

The compiled solution was tested both before and after the changes. Prior to the fix, the bot failed to trade the Pokémon, after the fix it succesfully completed the trade.