### PR TITLE
Fix double detach from controller

### DIFF
--- a/SysBot.Base/Control/BotSource.cs
+++ b/SysBot.Base/Control/BotSource.cs
@@ -22,10 +22,6 @@ public class BotSource<T>(RoutineExecutor<T> Bot)
         IsStopping = true;
         Source.Cancel();
         Source = new CancellationTokenSource();
-
-        Task.Run(async () => await Bot.HardStop()
-            .ContinueWith(ReportFailure, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously)
-            .ContinueWith(_ => IsPaused = IsRunning = IsStopping = false));
     }
 
     public void Pause()
@@ -50,7 +46,7 @@ public class BotSource<T>(RoutineExecutor<T> Bot)
         IsRunning = true;
         Task.Run(async () => await Bot.RunAsync(Source.Token)
             .ContinueWith(ReportFailure, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously)
-            .ContinueWith(_ => IsRunning = false));
+            .ContinueWith(_ => IsPaused = IsRunning = IsStopping = false));
     }
 
     public void Restart()


### PR DESCRIPTION
`Stop()` called `HardStop()` which was then called again by `MainLoop` once the token was cancelled. Removed from `Stop()`. Just let the main loop handle stopping upon receiving the cancellation token.  Moved `IsPaused` and `IsStopping` resets to the existing continuation in `Start()`

Closes #228 