### PR TITLE
Fix Idle/Resume functionality

### DIFF
--- a/SysBot.Base/Control/BotSource.cs
+++ b/SysBot.Base/Control/BotSource.cs
@@ -41,13 +41,11 @@ public class BotSource<T>(RoutineExecutor<T> Bot)
 
     public void Start()
     {
-        if (IsPaused)
-            Stop(); // can't soft-resume; just re-launch
-
         if (IsRunning || IsStopping)
             return;
 
         IsRunning = true;
+        Bot.Resume();
         Task.Run(async () => await Bot.RunAsync(Source.Token)
             .ContinueWith(ReportFailure, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously)
             .ContinueWith(_ => IsRunning = false));
@@ -97,6 +95,13 @@ public class BotSource<T>(RoutineExecutor<T> Bot)
 
     public void Resume()
     {
+        if (IsPaused)
+        {
+            Bot.Resume();
+            IsPaused = false;
+            return;
+        }
+
         Start();
     }
 }

--- a/SysBot.Base/Control/RoutineExecutor.cs
+++ b/SysBot.Base/Control/RoutineExecutor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,4 +45,5 @@ public abstract class RoutineExecutor<T>(IConsoleBotManaged<IConsoleConnection, 
     public abstract Task InitialStartup(CancellationToken token);
     public abstract void SoftStop();
     public abstract Task HardStop();
+    public abstract void Resume();
 }

--- a/SysBot.Pokemon/Actions/PokeRoutineExecutorBase.cs
+++ b/SysBot.Pokemon/Actions/PokeRoutineExecutorBase.cs
@@ -68,6 +68,8 @@ public abstract class PokeRoutineExecutorBase(IConsoleBotManaged<IConsoleConnect
 
     public override void SoftStop() => Config.Pause();
 
+    public override void Resume() => Config.Resume();
+
     public Task Click(SwitchButton b, int delayMin, int delayMax, CancellationToken token) =>
         Click(b, Util.Rand.Next(delayMin, delayMax), token);
 


### PR DESCRIPTION
Previously, Start() treated a paused bot by forcing a full Stop()/Start() since it couldn't soft-resume. The Main loop then referenced NextRoutineType which was still set to Idle. This adds a real Resume() implementation: RoutineExecutor gets an abstract Resume() method, PokeRoutineExecutorBase implements it via Config.Resume() which correctly references InitialRoutine, and BotSource.Resume() now calls Bot.Resume() and clears IsPaused directly when the bot is paused, instead of falling through to Start()

Closes #227 